### PR TITLE
Fix webpack warnings

### DIFF
--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -9,21 +9,14 @@ function requireModule<T>(modulePath: string): Promise<T> {
 
 export async function importEsri(modulePath: string): Promise<any> {
   const relativeModulePath = modulePath.replace(/^(@arcgis\/core\/|esri\/)/, '');
-
-  /**
-   * Removes the partial path information from the import statement, thus
-   * preventing webpack from bundling the entire Esri library.
-   * @see https://webpack.js.org/api/module-methods/#dynamic-expressions-in-import
-   */
-  const fullModulePath = `${amd ? 'esri' : '@arcgis/core'}/${relativeModulePath}`;
   if (amd) {
-    return requireModule(fullModulePath);
+    return requireModule(`esri/${relativeModulePath}`);
   }
 
   /**
    * @see https://webpack.js.org/api/module-methods/#webpackignore
    */
-  const module = await import(/* webpackIgnore: true */ fullModulePath);
+  const module = await import(/* webpackIgnore: true */ `@arcgis/core/${relativeModulePath}`);
   if (module.default) {
     return module.default;
   }

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -9,21 +9,13 @@ function requireModule<T>(modulePath: string): Promise<T> {
 
 export async function importEsri(modulePath: string): Promise<any> {
   const relativeModulePath = modulePath.replace(/^(@arcgis\/core\/|esri\/)/, '');
-
-  /**
-   * Removes the partial path information from the import statement, thus
-   * preventing webpack from bundling the entire Esri library.
-   * @see https://webpack.js.org/api/module-methods/#dynamic-expressions-in-import
-   */
-  const fullModulePath = `${amd ? 'esri' : '@arcgis/core'}/${relativeModulePath}`;
   if (amd) {
-    return requireModule(fullModulePath);
+    return requireModule(`esri/${relativeModulePath}`);
   }
-
-  /**
-   * @see https://webpack.js.org/api/module-methods/#webpackignore
-   */
-  const module = await import(/* webpackIgnore: true */ fullModulePath);
+  const module = await import(
+    /* webpackInclude: /^@arcgis\/core\/(config|portal\/Portal|core\/reactiveUtils|identity\/IdentityManager)/ */
+    `@arcgis/core/${relativeModulePath}`
+  );
   if (module.default) {
     return module.default;
   }

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -9,10 +9,17 @@ function requireModule<T>(modulePath: string): Promise<T> {
 
 export async function importEsri(modulePath: string): Promise<any> {
   const relativeModulePath = modulePath.replace(/^(@arcgis\/core\/|esri\/)/, '');
+
+  /**
+   * Removes the partial path information from the import statement, thus
+   * preventing webpack from bundling the entire Esri library.
+   * @see https://webpack.js.org/api/module-methods/#dynamic-expressions-in-import
+   */
+  const fullModulePath = `${amd ? 'esri' : '@arcgis/core'}/${relativeModulePath}`;
   if (amd) {
-    return requireModule(`esri/${relativeModulePath}`);
+    return requireModule(fullModulePath);
   }
-  const module = await import(`@arcgis/core/${relativeModulePath}`);
+  const module = await import(fullModulePath);
   if (module.default) {
     return module.default;
   }

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -19,7 +19,11 @@ export async function importEsri(modulePath: string): Promise<any> {
   if (amd) {
     return requireModule(fullModulePath);
   }
-  const module = await import(fullModulePath);
+
+  /**
+   * @see https://webpack.js.org/api/module-methods/#webpackignore
+   */
+  const module = await import(/* webpackIgnore: true */ fullModulePath);
   if (module.default) {
     return module.default;
   }

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -9,13 +9,21 @@ function requireModule<T>(modulePath: string): Promise<T> {
 
 export async function importEsri(modulePath: string): Promise<any> {
   const relativeModulePath = modulePath.replace(/^(@arcgis\/core\/|esri\/)/, '');
+
+  /**
+   * Removes the partial path information from the import statement, thus
+   * preventing webpack from bundling the entire Esri library.
+   * @see https://webpack.js.org/api/module-methods/#dynamic-expressions-in-import
+   */
+  const fullModulePath = `${amd ? 'esri' : '@arcgis/core'}/${relativeModulePath}`;
   if (amd) {
-    return requireModule(`esri/${relativeModulePath}`);
+    return requireModule(fullModulePath);
   }
-  const module = await import(
-    /* webpackInclude: /^@arcgis\/core\/(config|portal\/Portal|core\/reactiveUtils|identity\/IdentityManager)/ */
-    `@arcgis/core/${relativeModulePath}`
-  );
+
+  /**
+   * @see https://webpack.js.org/api/module-methods/#webpackignore
+   */
+  const module = await import(/* webpackIgnore: true */ fullModulePath);
   if (module.default) {
     return module.default;
   }


### PR DESCRIPTION
Some attempts to make webpack happy with the dynamic imports (which actually aren't used by ExB).

Will need to test these against some code that actually uses the dynamic import rather than the amd require to see if it breaks the component in other use cases.